### PR TITLE
updating previewer readme to lead users to the examples

### DIFF
--- a/frontend/previewer/README.md
+++ b/frontend/previewer/README.md
@@ -8,6 +8,9 @@ $ npm install -g browserify
 $ npm install -g https://anypixel-storage.appspot.com/npm/anypixel-previewer.tar.gz
 ```
 
+### Check out the examples 
+We've included 12 example apps written by Googlers and friends for the 8th Avenue lobby display in NYC. After installing the previewer, run one of the [examples](https://github.com/googlecreativelab/anypixel/tree/master/frontend/examples).
+
 ### Usage
 ```
 Usage:


### PR DESCRIPTION
The [website](http://googlecreativelab.github.io/anypixel/) drives people to the preview subfolder but doesn't tell you where the examples are.  I copied and tweaked the language from the README in the root of the repo to help make finding the examples a easier.  Might need some copy tweaking and I don't care if you refuse the pull request,  I just want something there that leads informs the visitors coming from the main website to where the examples exist
