### PR TITLE
Link to previewer app in README

### DIFF
--- a/frontend/examples/getting-started/README.md
+++ b/frontend/examples/getting-started/README.md
@@ -4,12 +4,14 @@ This is a small example app built with the Anypixel Framework.
 It draws colorful squares wherever you touch.
 
 To build it:
+
 ```sh
 $ npm install
 $ npm run build
 ```
 
-To run it, you'll need to install the [previewer app](#) first. Then in the app's root directory, do:
+To run it, you'll need to install the [previewer app](https://anypixel-storage.appspot.com/npm/anypixel-previewer.tar.gz) first. Then in the app's root directory, do:
+
 ```sh   
 preview
 ```


### PR DESCRIPTION
The getting-started example was a snap to install once I tracked down the link to the previewer. I've added it to the docs.
