### PR TITLE
Corrects and standardizes links to the previewer app

### DIFF
--- a/frontend/examples/automata/README.md
+++ b/frontend/examples/automata/README.md
@@ -12,7 +12,7 @@ or
 npm run build
 ```
 
-To run it, you'll need to install [Anypixel-Previewer](https://github.com/googlecreativelab/anypixel-previewer) first. Then in the app's root directory, do:
+To run it, you'll need to install the [previewer app](https://github.com/googlecreativelab/anypixel/tree/master/frontend/previewer) first. Then in the app's root directory, do:
 ```sh   
 preview
 ```

--- a/frontend/examples/getting-started/README.md
+++ b/frontend/examples/getting-started/README.md
@@ -9,7 +9,7 @@ $ npm install
 $ npm run build
 ```
 
-To run it, you'll need to install the [previewer app](#) first. Then in the app's root directory, do:
+To run it, you'll need to install the [previewer app](https://github.com/googlecreativelab/anypixel/tree/master/frontend/previewer) first. Then in the app's root directory, do:
 ```sh   
 preview
 ```

--- a/frontend/examples/inconvergent/README.md
+++ b/frontend/examples/inconvergent/README.md
@@ -4,9 +4,9 @@ forked from: https://github.com/googlecreativelab/anypixel-example
 
 ## Installation
 
-First you will need to install the Anypixel previewer:
+First you will need to install the previewer app:
 
-https://github.com/googlecreativelab/anypixel-previewer.
+https://github.com/googlecreativelab/anypixel/tree/master/frontend/previewer.
 
 The in the `app` directory do:
 

--- a/frontend/examples/iridescent-life/README.md
+++ b/frontend/examples/iridescent-life/README.md
@@ -18,7 +18,7 @@ For the blur algorithm that was used, see [ShaderLesson5](https://github.com/mat
 
 Read more about the spline drawing animation here: [How to move an object along a particular path](http://stackoverflow.com/a/17096947/6036193)
 
-run with the [Anypixel-Previewer](https://github.com/googlecreativelab/anypixel-previewer). In the app's root directory, do:
+run with the [previewer app](https://github.com/googlecreativelab/anypixel/tree/master/frontend/previewer). In the app's root directory, do:
 ```sh   
 preview
 ```

--- a/frontend/examples/subway/README.md
+++ b/frontend/examples/subway/README.md
@@ -11,7 +11,7 @@ or
 npm run build
 ```
 
-To run it, you'll need to install [Anypixel-Previewer](https://github.com/googlecreativelab/anypixel-previewer) first. Then in the app's root directory, do:
+To run it, you'll need to install the [previewer app](https://github.com/googlecreativelab/anypixel/tree/master/frontend/previewer) first. Then in the app's root directory, do:
 ```sh   
 preview
 ```


### PR DESCRIPTION
I had an issue where I went to getting started and the link to the previewer app was missing. I was able to find the link elsewhere. This pull request updates the other outdated links to the previewer app as well. 